### PR TITLE
Update input field name to match existing conventions.

### DIFF
--- a/views/ssrf.html
+++ b/views/ssrf.html
@@ -45,7 +45,7 @@
         <br>
         <label for="url-fragment">Input Value</label>
         <br>
-        <input name="untrusted-input" class="form-control">
+        <input name="input" class="form-control">
         <br>
         <button type="submit" class="btn btn-default">Submit</button>
       </form>


### PR DESCRIPTION
We typically just have `input` rather than `untrusted-input`. The naming in the ssrf template wasn't originally intentional; it was from a copy-paste oversight.