### PR TITLE
NODE-636 Add DangerousPaths route view

### DIFF
--- a/views/cmdInjectionSemanticDangerousPaths.ejs
+++ b/views/cmdInjectionSemanticDangerousPaths.ejs
@@ -1,0 +1,18 @@
+<h1 class="page-header"><%= name %></h1>
+<% include ../partials/ruleInfo.ejs %>
+<div class="row">
+  <div class="col-xs-12 col-sm-6" style="padding-bottom: 30px;">
+    <% groupedSinkData.query.forEach(function(sink) { %>
+    <% ['unsafe', 'safe', 'noop'].forEach(function(safety) { %>
+    <p>
+      <a
+        target="_blank"
+        href="<%= sink.url %>/<%= safety %>"
+      >
+        <%= sink.url %>/<%= safety %>
+      </a>
+    </p>
+    <% }); %>
+    <% }); %>
+  </div>
+</div>


### PR DESCRIPTION
This PR adds:

- A view for the CMDi Dangerous Paths Subrule
Pretty much followed suit with what @pmcclory-contrast did here (https://github.com/Contrast-Security-OSS/test-bench-content/pull/7) for the ChainedCommand view

Example:
<img width="1679" alt="Screen Shot 2020-02-28 at 1 56 03 PM" src="https://user-images.githubusercontent.com/14120224/75578594-1bd48a80-5a32-11ea-9cb9-f90cf4de49b0.png">

You can test by:

1. `npm link`
2. `npm link @contrast/test-bench-content` in a sample app directory.
3. Navigating to the view on `localhost:3000`.